### PR TITLE
fix `ridgeplot(showCategory = a_vector_of_terms)`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: enrichplot
 Title: Visualization of Functional Enrichment Result
-Version: 1.23.1
+Version: 1.23.1.991
 Authors@R: c(
     person(given = "Guangchuang", family = "Yu", email = "guangchuangyu@gmail.com",   role  = c("aut", "cre"), comment = c(ORCID = "0000-0002-6485-8781")),
     person(given = "Erqiang",     family = "Hu", email = "13766876214@163.com",       role = "ctb", comment = c(ORCID = "0000-0002-1798-7513")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# enrichplot 1.23.1.991
+
++ fix the issue in `ridgeplot(showCategory)` : support a vector of Description, not ID(2023-12-1, Fri, #193)
+
 # enrichplot 1.23.1
 
 + `ridgeplot()` supports passing a vector of selected pathways via the 'showCategory' parameter (2023-11-30, Thu, #193)

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -274,7 +274,9 @@ setGeneric("heatplot",
 ##' @title ridgeplot
 ##' @rdname ridgeplot
 ##' @param x gseaResult object
-##' @param showCategory number of categories for plotting
+##' @param showCategory A number or a vector of terms. If it is a number, 
+##' the first n terms will be displayed. If it is a vector of terms, 
+##' the selected terms will be displayed.
 ##' @param fill one of "pvalue", "p.adjust", "qvalue"
 ##' @param core_enrichment whether only using core_enriched genes
 ##' @param label_format a numeric value sets wrap length, alternatively a

--- a/R/ridgeplot.R
+++ b/R/ridgeplot.R
@@ -42,7 +42,8 @@ ridgeplot.gseaResult <- function(x, showCategory=30, fill="p.adjust",
     if (inherits(showCategory, 'numeric')) {
         selected <- seq_len(showCategory)
     } else if (inherits(showCategory, "character")) {
-        selected <- showCategory
+        ii <- match(showCategory, x@result$Description)
+        selected <- x@result[ii, "ID"]
     } else {
         warning("showCategory should be a number of pathways or a vector of selected pathways")
     }

--- a/man/ridgeplot.Rd
+++ b/man/ridgeplot.Rd
@@ -37,7 +37,9 @@ ridgeplot.gseaResult(
 \arguments{
 \item{x}{gseaResult object}
 
-\item{showCategory}{number of categories for plotting}
+\item{showCategory}{A number or a vector of terms. If it is a number, 
+the first n terms will be displayed. If it is a vector of terms, 
+the selected terms will be displayed.}
 
 \item{fill}{one of "pvalue", "p.adjust", "qvalue"}
 


### PR DESCRIPTION
修复 #193 提到的问题。`enrichplot`的其他函数均只支持输入一列Descriptions，而不是IDs，因此这个提交将ridgeplot也改成支持Descriptions，这也符合用户看着输出的大图中的term description名称而选取部分terms进行可视化的使用场景。
另外关于是否同时支持ID和Description的问题，我感觉必要性不强，同时支持太多也增加了用户使用的复杂度，所以还是保持仅支持数值和Descriptions。
<img width="736" alt="93b1a4c1a2c3496355c4fecac2c20c9" src="https://github.com/YuLab-SMU/enrichplot/assets/48857018/90cec09d-cbe3-46a8-89e2-c01997d148cc">
