### PR TITLE
adjust the JC similarity method

### DIFF
--- a/R/emapplot_utilities.R
+++ b/R/emapplot_utilities.R
@@ -11,17 +11,10 @@
 get_similarity_matrix <- function(y, geneSets, method, semData = NULL) {
     id <- y[, "ID"]
     geneSets <- geneSets[id]
-    n <- nrow(y)
     y_id <- unlist(strsplit(y$ID[1], ":"))[1]
     ## Choose the method to calculate the similarity
     if (method == "JC") {
-        w <- matrix(NA, nrow=n, ncol=n)
-        colnames(w) <- rownames(w) <- y$Description
-        for (i in seq_len(n-1)) {
-            for (j in (i+1):n) {
-                w[i,j] <- overlap_ratio(geneSets[id[i]], geneSets[id[j]])
-            }
-        }
+        w <- .cal_jc_similarity(geneSets, id = id, name = y$Description)
         return(w)
     }
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -202,6 +202,26 @@ overlap_ratio <- function(x, y) {
     length(intersect(x, y))/length(unique(c(x,y)))
 }
 
+.cal_jc_similarity <- function(gsetlist, id = NULL, name=NULL){
+    if (is.null(id)) {
+        id <- names(gsetlist)
+    }
+    n <- length(id)
+    w <- matrix(NA, nrow=n, ncol=n)
+    if (is.null(name)) {
+        name <- id 
+    }
+    colnames(w) <- rownames(w) <- name
+    for (i in seq_len(n-1)) {
+        for (j in (i+1):n) {
+            w[i,j] <- overlap_ratio(gsetlist[id[i]], gsetlist[id[j]])
+        }
+    }
+    w[lower.tri(w)] <- t(w)[lower.tri(t(w))]
+    diag(w) <- 1    
+    return(w)
+}
+
 fc_readable <- function(x, foldChange = NULL) {
     if (is.null(foldChange))
         return(NULL)


### PR DESCRIPTION
`JC` similarity method was separated in `pairwise_termsim`.

and the `.cal_jc_similarity` can support the list which contains gene sets.