### PR TITLE
Added log transformation argument for color scale

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Imports:
     DOSE (>= 3.31.2),
     ggfun (>= 0.1.7),
     ggnewscale,
-    ggplot2,
+    ggplot2 (>= 3.5.0),
     ggrepel (>= 0.9.0),
     ggtangle (>= 0.0.5),
     graphics,

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -19,7 +19,7 @@ get_enrichplot_color <- function(n = 2) {
 
     if (n != 2 && n != 3) stop("'n' should be 2 or 3")
 
-    colors = c("#e06663", "#327eba")
+    colors = c("#ec2b54", "#005087")
     if (n == 2) return(colors)
 
     if (n == 3) return(c(colors[1], "white", colors[2]))
@@ -34,6 +34,7 @@ get_enrichplot_color <- function(n = 2) {
 ##' @param name name of the color legend
 ##' @param .fun force to use user provided color scale function
 ##' @param reverse whether reverse the color scheme, default is TRUE as it is more significant for lower pvalue
+##' @param log_transform whether or not to log-transform the color scale, default is TRUE as p-values operate over a wide range of orders of magnitude
 ##' @param ... additional parameter that passed to the color scale function
 ##' @return a color scale
 ##' @importFrom ggplot2 scale_fill_continuous
@@ -42,7 +43,8 @@ get_enrichplot_color <- function(n = 2) {
 ##' @importFrom ggplot2 scale_color_gradientn
 ##' @export
 set_enrichplot_color <- function(colors = get_enrichplot_color(2), 
-                                type = "color", name = NULL, .fun = NULL, reverse=TRUE, ...) {
+                                type = "color", name = NULL, .fun = NULL, 
+                                reverse = TRUE, log_transform = TRUE, ...) {
 
     type <- match.arg(type, c("color", "colour", "fill"))
     if (!reverse) colors = rev(colors)
@@ -77,6 +79,9 @@ set_enrichplot_color <- function(colors = get_enrichplot_color(2),
 
     params$guide <- guide_colorbar(reverse=reverse, order=1)
     params$name <- name # no legend name setting by default as 'name = NULL'
+    if (log_transform) {
+        params$transform <- "log10"
+    }
 
     params <- modifyList(params, list(...))
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -19,7 +19,7 @@ get_enrichplot_color <- function(n = 2) {
 
     if (n != 2 && n != 3) stop("'n' should be 2 or 3")
 
-    colors = c("#ec2b54", "#005087")
+    colors = c("#e06663", "#327eba")
     if (n == 2) return(colors)
 
     if (n == 3) return(c(colors[1], "white", colors[2]))


### PR DESCRIPTION
Because p-values are often more symmetrically distributed on a log scale, the current color scale leads to many instances of plots where the highest p-value is orders of magnitude larger than all other p-values, so the largest p-value shows up as blue, and all others are an indistinguishable shade of red. See:

![example_enrichplot_4](https://github.com/user-attachments/assets/012b3dc2-21b4-4672-96fc-7d854c3276e7)
![example_enrichplot_3](https://github.com/user-attachments/assets/5250e354-57c8-4073-bf5f-a466428ef39f)
![example_enrichplot_2](https://github.com/user-attachments/assets/d3c88b69-ad06-4e9f-933c-48ce25293b01)
![example_enrichplot_1](https://github.com/user-attachments/assets/c7c43f30-28a2-4a0e-9ffa-b92e48ad16a4)

Because the field standard is to display p-values on a log scale (e.g. in a volcano plot), this PR adds an option to the `set_enrichplot_color` function that transforms the color scale to a log scale, and makes it the default.