### PR TITLE
Fix BP ontology check

### DIFF
--- a/R/goplot.R
+++ b/R/goplot.R
@@ -46,7 +46,7 @@ goplot.enrichResult <- function(x, showCategory = 10, color = "p.adjust",
         onto <- x@ontology
     }
 
-    if (!toupper(onto) %in% c("MF", "CC", "BF")) {
+    if (!toupper(onto) %in% c("MF", "CC", "BP")) {
         stop("Ontology should be one of 'MF', 'CC' or 'BP'")
     }
 


### PR DESCRIPTION
Recently, the ontology check was introduced to `goplot`, but there was a typo where `BP` was incorrectly specified as `BF`. This was subsequently fixed in the message, but not in the `if` condition/check, so `goplot` couldn't plot `BP` ontologies as it expected to find `BF`. 