### PR TITLE
Heatplot reverse colors

### DIFF
--- a/R/heatplot.R
+++ b/R/heatplot.R
@@ -134,6 +134,7 @@ heatplot.enrichResult <- function(
             set_enrichplot_color(
                 colors = get_enrichplot_color(3),
                 type = "fill",
+                reverse = FALSE,
                 transform = 'identity'
             )
     }

--- a/R/heatplot.R
+++ b/R/heatplot.R
@@ -37,6 +37,7 @@ setMethod(
 heatplot.enrichResult <- function(
     x,
     showCategory = 30,
+    showTop = NULL,
     symbol = "rect",
     foldChange = NULL,
     pvalue = NULL,
@@ -50,6 +51,10 @@ heatplot.enrichResult <- function(
 
     n <- update_n(x, showCategory)
     geneSets <- extract_geneSets(x, n)
+    if(!is.null(showTop) && showTop > 0) {
+      topgenes <- head(names(sort(table(unlist(geneSets)),decreasing=TRUE)), showTop)
+      geneSets <- lapply(geneSets, function(s) intersect(s, topgenes))
+    }
     foldChange <- fc_readable(x, foldChange)
     pvalue <- fc_readable(x, pvalue)
     d <- list2df(geneSets)

--- a/R/heatplot.R
+++ b/R/heatplot.R
@@ -52,8 +52,8 @@ heatplot.enrichResult <- function(
     n <- update_n(x, showCategory)
     geneSets <- extract_geneSets(x, n)
     if(!is.null(showTop) && showTop > 0) {
-      genes_freq <- table(unlist(geneSets))
-      nfc <- genes_freq * abs(foldChange[ names(genes_freq) ])
+      nfreq <- table(unlist(geneSets))
+      nfc <- nfreq * abs(foldChange[ names(nfreq) ])
       topgenes <- head(names(sort(nfc,decreasing=TRUE)), showTop)
       geneSets <- lapply(geneSets, function(s) intersect(s, topgenes))
     }

--- a/R/heatplot.R
+++ b/R/heatplot.R
@@ -52,7 +52,9 @@ heatplot.enrichResult <- function(
     n <- update_n(x, showCategory)
     geneSets <- extract_geneSets(x, n)
     if(!is.null(showTop) && showTop > 0) {
-      topgenes <- head(names(sort(table(unlist(geneSets)),decreasing=TRUE)), showTop)
+      genes_freq <- table(unlist(geneSets))
+      nfc <- genes_freq * abs(foldChange[ names(genes_freq) ])
+      topgenes <- head(names(sort(nfc,decreasing=TRUE)), showTop)
       geneSets <- lapply(geneSets, function(s) intersect(s, topgenes))
     }
     foldChange <- fc_readable(x, foldChange)


### PR DESCRIPTION
In heatplot the foldchanged both colors and numbers in color scale are reversed. Fix by adding reverse=FALSE. 

**Before fix:**
<img width="1775" height="488" alt="image" src="https://github.com/user-attachments/assets/681406b4-5463-4e88-910a-cfd81a5381e2" />



**After fix:**
<img width="1775" height="488" alt="image" src="https://github.com/user-attachments/assets/ee6d5303-c718-44fb-83eb-cb0495038830" />
