### PR TITLE
Add fc_threshold parameter to cnetplot

### DIFF
--- a/R/cnetplot.R
+++ b/R/cnetplot.R
@@ -13,6 +13,7 @@
 #' @param size_edge relative size of edge
 #' @param node_label one of 'all', 'none', 'category', 'item', 'exclusive' or 'share'
 #' @param foldChange numeric values to color the item (e.g, foldChange of gene expression values)
+#' @param fc_threshold threshold for filtering genes by absolute fold change (e.g., fc_threshold = 1 keeps only genes with |foldChange| > 1)
 #' @param hilight selected category to be highlighted
 #' @param hilight_alpha transparent value for not selected to be highlight
 #' @param ... additional parameters
@@ -33,12 +34,24 @@ cnetplot.enrichResult <- function(
     size_edge = .5,
     node_label = "all",
     foldChange = NULL,
+    fc_threshold = NULL,
     hilight = "none",
     hilight_alpha = .3,
     ...
 ) {
     geneSets <- extract_geneSets(x, showCategory)
     foldChange <- fc_readable(x, foldChange)
+
+    # Filter genes by absolute fold change threshold
+    if (!is.null(fc_threshold) && !is.null(foldChange)) {
+        keep_genes <- names(foldChange)[abs(foldChange) > fc_threshold]
+        foldChange <- foldChange[keep_genes]
+        geneSets <- lapply(geneSets, function(gs) {
+            intersect(gs, keep_genes)
+        })
+        # Remove empty gene sets
+        geneSets <- geneSets[sapply(geneSets, length) > 0]
+    }
 
     p <- cnetplot(
         geneSets,


### PR DESCRIPTION
## Summary
- Add new `fc_threshold` parameter to `cnetplot.enrichResult` function
- Filters genes to only include those with `|foldChange| > fc_threshold`
- Allows users to plot only high fold-change genes (e.g., `fc_threshold = 1`)

## Usage
```r
cnetplot(x, foldChange = fc, fc_threshold = 1)
```

## Example
**Left:** cnetplot with fc_theshold=NULL (=0) default behaviour plotting all genes for concept. 
**Right:**  cnetplot with fc_threshold=1.5. Plotting only genes with abs(fc)>1.5. The plot is smaller and better readable.

<img width="45%" halt="image" src="https://github.com/user-attachments/assets/e6bdc007-9e7c-43db-9082-36a13ce7cd3a" />
<img width="45%" halt="image" src="https://github.com/user-attachments/assets/fff0a5e1-2c32-474f-a3b4-a6ed20a61518" />



