### PR TITLE
fix mismatch between label and data in tableGrob2

### DIFF
--- a/R/ggtable.R
+++ b/R/ggtable.R
@@ -19,7 +19,11 @@ ggtable <- function(d, p = NULL) {
 #' @importFrom rlang check_installed
 tableGrob2 <- function(d, p = NULL, rows=NULL) {
     # has_package("gridExtra")
-    d <- d[order(rownames(d)),]
+    order_index <- order(rownames(d))
+    d <- d[order_index,]
+    if (!is.null(rows)) {
+        rows <- rows[order_index]
+    }
     check_installed('gridExtra', 'for `tableGrob2()`.')
     tp <- gridExtra::tableGrob(d, rows=rows)
     if (is.null(p) || is.null(rows)) {


### PR DESCRIPTION
修复 gseaplot2 画图时 pvalue_table_rownames 与 pvalue_table_columns 不匹配问题